### PR TITLE
NPC-2 remove stupid routing for whitelist

### DIFF
--- a/src/Coverage.php
+++ b/src/Coverage.php
@@ -171,7 +171,7 @@ class Coverage
             return false;
         } else {
             foreach ($this->whiteList as $dir) {
-                $this->phpCC->filter()->addDirectoryToWhitelist($_SERVER['DOCUMENT_ROOT'] . '/../../' . $dir);
+                $this->phpCC->filter()->addDirectoryToWhitelist($_SERVER['DOCUMENT_ROOT'] . $dir);
             }
         }
     }


### PR DESCRIPTION
:warning: **Now we must set paths for white list as paths from DOCUMENT_ROOT directory of executed script!** :warning: 